### PR TITLE
Fix `install-shared` Make task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ install:	$(TARGETS)
 install-shared:
 	if test `uname` = Darwin; then \
 		$(MAKE) DSONAME="libpdfio.1.dylib" -$(MAKEFLAGS) install; \
-	else
+	else \
 		$(MAKE) DSONAME="libpdfio.so.1" -$(MAKEFLAGS) install; \
 	fi
 


### PR DESCRIPTION
Issue before fix
```
if test `uname` = Darwin; then \
	make DSONAME="libpdfio.1.dylib" - install; \
else
/bin/sh: -c: line 4: syntax error: unexpected end of file
make: *** [Makefile:121: install-shared] Error 2
```
Which was caused by the missing `\` on line 123

Adding that in fixed it and allowed me to install correctly