### PR TITLE
Fix text trailing parenthesis in pdfioStreamGetToken

### DIFF
--- a/pdfio-token.c
+++ b/pdfio-token.c
@@ -259,6 +259,7 @@ _pdfioTokenRead(_pdfio_token_t *tb,	// I - Token buffer/stack
   switch (state)
   {
     case '(' : // Literal string
+	parens = 1;
 	while ((ch = get_char(tb)) != EOF)
 	{
 	  if (ch == 0)
@@ -332,9 +333,6 @@ _pdfioTokenRead(_pdfio_token_t *tb,	// I - Token buffer/stack
 	  }
 	  else if (ch == ')')
 	  {
-	    if (parens == 0)
-	      break;
-
 	    parens --;
 	  }
 
@@ -349,6 +347,9 @@ _pdfioTokenRead(_pdfio_token_t *tb,	// I - Token buffer/stack
 	    _pdfioFileError(tb->pdf, "Token too large.");
 	    return (false);
 	  }
+
+	  if (parens == 0)
+	    break;
 	}
 
 	if (ch != ')')


### PR DESCRIPTION
#### Problem

At the moment, when the `pdfioStreamGetToken` parses a text token, it isn't returning the trailing closing parenthesis, e.g.:

```
% expected token:
(my text)
% got token:
(my text
```

#### Solution

When parsing a text token, prevent the logic from early returning before adding the trailing closing parenthesis to the buffer.