### PR TITLE
added windows.h header for GetTempPathA

### DIFF
--- a/pdfio-private.h
+++ b/pdfio-private.h
@@ -23,6 +23,7 @@
 #  ifdef _WIN32
 #    include <io.h>
 #    include <direct.h>
+#    include <windows.h> // GetTempPathA
 #    define access	_access		// Map standard POSIX/C99 names
 #    define close	_close
 #    define fileno	_fileno


### PR DESCRIPTION
Without the fix, you get 
```
warning C4013: 'GetTempPathA' undefined; assuming extern returning int
```

in Visual Studio 2019