### PR TITLE
Added missing initialization for ivlen when pdf encryption is PDFIO_E…

### DIFF
--- a/pdfio-crypto.c
+++ b/pdfio-crypto.c
@@ -446,6 +446,7 @@ _pdfio_crypto_cb_t			// O  - Decryption callback or `NULL` for none
 
         // Initialize the RC4 context using 40 bits of the digest...
 	_pdfioCryptoRC4Init(&ctx->rc4, digest, 5);
+  *ivlen = 0;
 	return ((_pdfio_crypto_cb_t)_pdfioCryptoRC4Crypt);
 
     case PDFIO_ENCRYPTION_RC4_128 :


### PR DESCRIPTION
Hey my dudes, great project. Keep up the good work.

I currently have a crash when supplying the following pdf to `pdfiototext` - [bad.pdf](https://files.catbox.moe/fo523x.pdf)

```
$ sha256sum bad.pdf
130134c62521d1a29813fa8c2090441c31c7107dee59f96aefc0fc75a2e5d6b2  bad.pdf
$ ./pdfiototext bad.pdf
Segmentation fault
```

Performing some light root-cause analysis shows a missing initialization of the `ivlen` variable in `pdfio-crypto.c`. 

If `pdf->encryption` is `PDFIO_ENCRYPTION_RC4_40`, then the `ivlen` variable will not be initialized and later used in `_pdfioCryptoRC4Crypt` leading to undefined behavior. 

Cheers! :beer: