### PR TITLE
add support for the meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,99 @@
+project('pdfio', 'c',
+    version: '1.1.4',
+    meson_version: '>=0.49.0',
+    default_options: [
+        'optimization=s',
+        'debug=true',
+        'default_library=static',
+    ]
+)
+
+cc = meson.get_compiler('c')
+
+deps = [
+    cc.find_library('m', required: false),
+    dependency('zlib', version: '>=1.0'),
+]
+
+
+pubheaders = [
+    'pdfio.h',
+    'pdfio-content.h',
+]
+pubsrcs = [
+    'pdfio-aes.c',
+    'pdfio-array.c',
+    'pdfio-common.c',
+    'pdfio-content.c',
+    'pdfio-crypto.c',
+    'pdfio-dict.c',
+    'pdfio-file.c',
+    'pdfio-md5.c',
+    'pdfio-object.c',
+    'pdfio-page.c',
+    'pdfio-rc4.c',
+    'pdfio-sha256.c',
+    'pdfio-stream.c',
+    'pdfio-string.c',
+    'pdfio-token.c',
+    'pdfio-value.c',
+]
+libsrcs = pubsrcs + [
+    'ttf.c',
+]
+srcs = pubsrcs + [
+    'pdfiototext.c',
+    'testpdfio.c',
+    'testttf.c',
+]
+
+_libpdfio = static_library('_pdfio', libsrcs,
+    dependencies: deps,
+)
+libpdfio = library('pdfio',
+    dependencies: deps,
+    link_whole: _libpdfio,
+    vs_module_defs: 'pdfio1.def',
+    version: '1',
+    darwin_versions: ['1.0', meson.project_version()],
+    install: true
+)
+pdfio_dep = declare_dependency(
+    link_with: libpdfio,
+    include_directories: include_directories('.'),
+)
+import('pkgconfig').generate(libpdfio,
+    description: 'PDF read/write library',
+    url: 'https://www.msweet.org/pdfio',
+)
+install_headers(pubheaders)
+install_man('doc/pdfio.3')
+install_data('doc/pdfio.html', 'doc/pdfio-512.png', 'LICENSE', 'NOTICE',
+    install_dir: get_option('datadir') / 'doc/pdfio',
+)
+
+executable('pdfiototext', 'pdfiototext.c',
+    dependencies: deps,
+    link_with: libpdfio,
+)
+
+
+# tests
+testttf = executable('testttf', 'testttf.c', 'ttf.c',
+    dependencies: deps,
+)
+test('testttf', testttf,
+    workdir: meson.current_source_dir(),
+)
+testpdfio = executable('testpdfio', 'testpdfio.c',
+    dependencies: deps,
+    # links with private APIs
+    link_with: _libpdfio,
+)
+test('testpdfio', testpdfio,
+    workdir: meson.current_source_dir(),
+)
+
+add_test_setup('valgrind',
+    exe_wrapper: ['valgrind', '--leak-check=full'],
+)

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = zlib-1.3
+source_url = http://zlib.net/fossils/zlib-1.3.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.3-5/zlib-1.3.tar.gz
+source_filename = zlib-1.3.tar.gz
+source_hash = ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
+patch_filename = zlib_1.3-5_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3-5/get_patch
+patch_hash = 524fb7648b68474a00c0e2d27e0ca707fb4ba0eb6d510d4f18f29cf656ba2b8b
+wrapdb_version = 1.3-5
+
+[provide]
+zlib = zlib_dep


### PR DESCRIPTION
I'm trying to package this for Gentoo and I ran into a couple of snags with the plain Makefile. After struggling with it a bit I decided it would probably be significantly easier to start from scratch. I'm curious what your thoughts are on the matter.

For a bit of context: meson is a cross platform build system with two implementations:
- reference implementation, python: https://mesonbuild.com/
- c99 zero-dependency self-bootstrapping: https://sr.ht/~lattis/muon/

Some things you get for free:
- generate Windows msbuild projects or macOS xcode projects, abstracting away the tiresome work of maintaining such by hand
- builtin support for GNU install directories
- builtin support for selecting shared/static libraries
- builtin support for sanitizers
- builtin support for GCC depfiles
- users can easily apply compiler/flag policies (POSIX makefiles don't provide good ways to override variables, and passing a dozen FOO=$FOO arguments gets kludgy)
- trivial to embed as a submodule in another meson project: https://mesonbuild.com/Wrap-dependency-system-manual.html or see how the zlib subproject here works.
- test harness which summarizes successes and prints test output only on failure
- test harness automatically handles MALLOC_PERTURB and sanitizers

This can still coexist quite happily with the existing Makefile. As a result, I haven't implemented maintainer targets (codedoc, regenerating the MSVC def file) at all.

If interested, I am happy to volunteer to maintain this, too.