### PR TITLE
fix misspelled variable: PKCONFIG

### DIFF
--- a/configure
+++ b/configure
@@ -1898,9 +1898,7 @@ struct stat;
 /* Most of the following tests are stolen from RCS 5.7 src/conf.sh.  */
 struct buf { int x; };
 struct buf * (*rcsopen) (struct buf *, struct stat *, int);
-static char *e (p, i)
-     char **p;
-     int i;
+static char *e (char **p, int i)
 {
   return p[i];
 }
@@ -1951,6 +1949,7 @@ extern int puts (const char *);
 extern int printf (const char *, ...);
 extern int dprintf (int, const char *, ...);
 extern void *malloc (size_t);
+extern void free (void *);
 
 // Check varargs macros.  These examples are taken from C99 6.10.3.5.
 // dprintf is used instead of fprintf to avoid needing to declare
@@ -4024,7 +4023,7 @@ then :
 printf "%s\n" "#define STDC_HEADERS 1" >>confdefs.h
 
 fi
-if $PKCONFIG --exists zlib
+if $PKGCONFIG --exists zlib
 then :
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
@@ -4055,8 +4054,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char inflateCopy ();
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char inflateCopy (void);
 int
 main (void)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -103,7 +103,7 @@ AC_SUBST([PKGCONFIG_REQUIRES])
 
 dnl ZLIB
 AC_MSG_CHECKING([for zlib via pkg-config])
-AS_IF([$PKCONFIG --exists zlib], [
+AS_IF([$PKGCONFIG --exists zlib], [
     AC_MSG_RESULT([yes])
     LIBS="$($PKGCONFIG --libs zlib) $LIBS"
     CPPFLAGS="$($PKGCONFIG --cflags zlib) $CPPFLAGS"


### PR DESCRIPTION
This prevented using pkg-config for zlib lookup.

As noted elsewhere, using pkg.m4's PKG_CHECK_MODULES would handle quite a bit of this for you...