### PR TITLE
pdfio.pc: use -lm as specified in configure

### DIFF
--- a/pdfio.pc.in
+++ b/pdfio.pc.in
@@ -9,5 +9,5 @@ Version: @PDFIO_VERSION@
 URL: https://www.msweet.org/pdfio
 Requires: @PKGCONFIG_REQUIRES@
 Libs: @PKGCONFIG_LIBS@
-Libs.private: @PKGCONFIG_LIBS_PRIVATE@ -lm
+Libs.private: @PKGCONFIG_LIBS_PRIVATE@
 Cflags: @PKGCONFIG_CFLAGS@


### PR DESCRIPTION
It is already configured in, in the correct place. Currently, it is listed twice in Libs.private, if --enable-shared is used. And it is redundant if the build is static instead, since it is recorded in Libs.