### PR TITLE
Update documentation

### DIFF
--- a/doc/pdfio.md
+++ b/doc/pdfio.md
@@ -345,7 +345,7 @@ to the stream:
 The [PDF content helper functions](@) provide additional functions for writing
 specific PDF page stream commands.
 
-When you are done writing the stream, call [`pdfioStreamCLose`](@@) to close
+When you are done writing the stream, call [`pdfioStreamClose`](@@) to close
 both the stream and the object.
 
 

--- a/pdfio-content.c
+++ b/pdfio-content.c
@@ -2349,7 +2349,7 @@ pdfioPageDictAddColorSpace(
 bool					// O - `true` on success, `false` on failure
 pdfioPageDictAddFont(
     pdfio_dict_t *dict,			// I - Page dictionary
-    const char   *name,			// I - Font name
+    const char   *name,			// I - Font name; must not contain spaces
     pdfio_obj_t  *obj)			// I - Font object
 {
   pdfio_dict_t	*resources;		// Resource dictionary


### PR DESCRIPTION
While using the library I came across two things. I found a typo. The other thing is that I used spaces in the `name` parameter in the following function:
```
bool pdfioPageDictAddFont(pdfio_dict_t *dict, const char *name, pdfio_obj_t *obj);
```
Having whitespace characters in the font name led to a blank looking pdf when opening it with zathura or evince. Removing the whitespace fixed it. I thought it would be helpful for future users to mention this in the documentation.

I enjoy using the library. Thanks. Feel free to just close the pull request if you're not interested.