### PR TITLE
Fixed compilation error MSVC 19.16.27039.0 32 bit

### DIFF
--- a/ttf.h
+++ b/ttf.h
@@ -11,6 +11,7 @@
 
 #ifndef TTF_H
 #  define TTF_H
+#  include <stddef.h>
 #  include <stdbool.h>
 #  include <sys/types.h>
 #  ifdef __cplusplus


### PR DESCRIPTION
I came across compilation error with MSVC 19.16.27039.0 32 bit. 
It seems that we need to #include <stddef.h> to provide size_t on some MSVC compilers.