### PR TITLE
examples/Makefile: libm is not added by default by all

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,7 +15,7 @@
 CFLAGS		=	-g $(CPPFLAGS)
 #CFLAGS		=	-g -fsanitize=address $(CPPFLAGS)
 CPPFLAGS	=	-I.. -I/usr/local/include
-LIBS		=	-L.. -L/usr/local/lib -lpdfio -lz
+LIBS		=	-L.. -L/usr/local/lib -lpdfio -lz -lm
 
 
 # Targets


### PR DESCRIPTION
-lm has to be added for system/compilers that don't add the lib by default (the case on NetBSD).