### PR TITLE
Fix undefined behavior in _pdfioFileSeek

### DIFF
--- a/pdfio-common.c
+++ b/pdfio-common.c
@@ -368,7 +368,7 @@ _pdfioFileSeek(pdfio_file_t *pdf,	// I - PDF file
   if (pdf->mode == _PDFIO_MODE_READ)
   {
     // Reading, see if we already have the data we need...
-    if (whence != SEEK_END && offset >= pdf->bufpos && offset < (pdf->bufpos + pdf->bufend - pdf->buffer))
+    if (whence != SEEK_END && offset >= pdf->bufpos && pdf->bufend && offset < (pdf->bufpos + pdf->bufend - pdf->buffer))
     {
       // Yes, seek within existing buffer...
       pdf->bufptr = pdf->buffer + (offset - pdf->bufpos);


### PR DESCRIPTION
In some scenarios the following situation is possible in _pdfioFileSeek:

1. This condition is true: // Reading, see if we already have the data we need... 
2. But pdf->bufend and pdf->bufptr are NULL

In this case we have undefined behavior because 
1. (pdf->bufpos + pdf->bufend - pdf->buffer) now depends on pdf->buffer address only (but not on buffer length)
2. pdf->bufptr = pdf->buffer + (offset - pdf->bufpos);  // now we have pdf->bufptr without pdf->bufend

I came across this situaltion in Linux/i386 architecture only but I think it's possible also for x64.

I propose a simple solution: to check also pdf->bufend.