### PR TITLE
Fix UTF-16-LE vs UTF-16-BE discriminator

### DIFF
--- a/pdfio-dict.c
+++ b/pdfio-dict.c
@@ -469,7 +469,7 @@ pdfioDictGetString(pdfio_dict_t *dict,	// I - Dictionary
 		*tempptr;		// Pointer into temporary string
     unsigned char *dataptr;		// Pointer into the data string
 
-    if (!(value->value.binary.datalen & 1) && !memcmp(value->value.binary.data, "\377\376", 2))
+    if (!(value->value.binary.datalen & 1) && !memcmp(value->value.binary.data, "\376\377", 2))
     {
       // Copy UTF-16 BE
       int	ch;			// Unicode character
@@ -528,7 +528,7 @@ pdfioDictGetString(pdfio_dict_t *dict,	// I - Dictionary
 
       *tempptr = '\0';
     }
-    else if (!(value->value.binary.datalen & 1) && !memcmp(value->value.binary.data, "\376\377", 2))
+    else if (!(value->value.binary.datalen & 1) && !memcmp(value->value.binary.data, "\377\376", 2))
     {
       // Copy UTF-16 LE
       int	ch;			// Unicode character


### PR DESCRIPTION
The Byte Order Mark for telling apart UTF-16-LE and BE was mixed up. See a reference here: https://en.wikipedia.org/wiki/Byte_order_mark#UTF-16 

- `FEFF` indicates a Big Endian case (`\376\377`)
- `FFFE` indicates a Little Endian case (`\377\376`)

How this was detected? I was retrieving form field names using `pdfioDictGetString(dict, "T")`, and was getting the following messed up output 
```
倀琀㤀䰀椀渀攀㘀挀开䤀琀攀洀一甀洀戀攀爀嬀㄀崀
䰀椀渀攀㄀开匀椀最渀愀琀甀爀攀嬀　崀
䰀椀渀攀㈀开匀椀最渀愀琀甀爀攀匀琀甀搀攀渀琀嬀　崀
```

And after the fix:
```
Pt9Line6c_ItemNumber[1]
Line1_Signature[0]
Line2_SignatureStudent[0]
```

The PDF file I used to test contains the field names encoded in UTF-16-LE, knew that by inspection and by prior tests with other library which only works with UTF-16-LE (pdfium). Find it here: [g-28.pdf](https://github.com/user-attachments/files/19498023/g-28.pdf)