### PR TITLE
Correct printf specifier from '%N' to '%s'

### DIFF
--- a/pdfio-stream.c
+++ b/pdfio-stream.c
@@ -623,7 +623,7 @@ _pdfioStreamOpen(pdfio_obj_t *obj,	// I - Object
     else
     {
       // Something else we don't support
-      _pdfioFileError(st->pdf, "Unsupported stream filter '%N'.", filter);
+      _pdfioFileError(st->pdf, "Unsupported stream filter '%s'.", filter);
       goto error;
     }
   }


### PR DESCRIPTION
I came across this error message while extracting images from a pdf file. I assume the printf conversion specifier should have been `%s`.