### PR TITLE
Correct PDF trailer: output %%EOF instead of %EOF

### DIFF
--- a/pdfio-file.c
+++ b/pdfio-file.c
@@ -2964,7 +2964,7 @@ write_trailer(pdfio_file_t *pdf)	// I - PDF file
     }
   }
 
-  if (!_pdfioFilePrintf(pdf, "\nstartxref\n%lu\n%%EOF\n", (unsigned long)xref_offset))
+  if (!_pdfioFilePrintf(pdf, "\nstartxref\n%lu\n%%%%EOF\n", (unsigned long)xref_offset))
   {
     _pdfioFileError(pdf, "Unable to write xref offset.");
     ret = false;


### PR DESCRIPTION
Root cause: the trailer is written using a printf-style format string with %%EOF, which prints a single % at runtime. To emit a literal %%EOF, the format string must use %%%%EOF (or write the bytes without formatting)

Fix for #135 