### PR TITLE
Fixing _pdfio_utf16cpy utf-8,  4 bytes leading byte  

### DIFF
--- a/pdfio-string.c
+++ b/pdfio-string.c
@@ -229,7 +229,7 @@ _pdfio_utf16cpy(
     else
     {
       // 4-byte UTF-8
-      *dstptr++ = (char)(0xe0 | (ch >> 18));
+      *dstptr++ = (char)(0xf0 | (ch >> 18));
       *dstptr++ = (char)(0x80 | ((ch >> 12) & 0x3f));
       *dstptr++ = (char)(0x80 | ((ch >> 6) & 0x3f));
       *dstptr++ = (char)(0x80 | (ch & 0x3f));


### PR DESCRIPTION
This pull request fixes the lead byte mask used for 4-byte UTF-8 sequences in the _pdfio_utf16cpy function. The code was previously using 0xe0, which is the standard prefix for 3-byte characters, but the UTF-8 specification requires 0xf0 for 4-byte sequences (characters above U+FFFF). This change ensures that high-range characters, such as emojis and specific mathematical symbols, are encoded correctly according to international standards.