### PR TITLE
Fix UTF-16 encoding of supplementary plane characters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ v1.7.0 - YYYY-MM-DD
 - Added `pdfioPageGetXxx` functions to get values from the page dictionaries
   (Issue #150)
 - Fixed a buffer overflow in the (still not enabled) AES-256 code.
+- Fixed UTF-16 encoding of supplementary plane characters (U+10000 and above).
 
 
 v1.6.4 - 2026-06-05

--- a/pdfio-content.c
+++ b/pdfio-content.c
@@ -4513,7 +4513,7 @@ write_string(pdfio_stream_t *st,	// I - Stream
     if (unicode)
     {
       // Write UTF-16 in hex...
-      if (ch < 0x100000)
+      if (ch < 0x10000)
       {
         // Two-byte UTF-16
 	if (!pdfioStreamPrintf(st, "%04X", ch))
@@ -4521,7 +4521,8 @@ write_string(pdfio_stream_t *st,	// I - Stream
       }
       else
       {
-        // Four-byte UTF-16
+        // Four-byte UTF-16 (surrogate pair)
+	ch -= 0x10000;
 	if (!pdfioStreamPrintf(st, "%04X%04X", 0xd800 | ((ch >> 10) & 0x03ff), 0xdc00 | (ch & 0x03ff)))
 	  return (false);
       }

--- a/testpdfio.c
+++ b/testpdfio.c
@@ -36,6 +36,7 @@ static int	do_crypto_tests(void);
 static int	do_lzw_tests(void);
 static int	do_pdfa_tests(void);
 static int	do_test_file(const char *filename, const char *outfile, int objnum, const char *password, bool decode, bool verbose);
+static int	do_unicode_tests(void);
 static int	do_unit_tests(void);
 static int	draw_image(pdfio_stream_t *st, const char *name, double x, double y, double w, double h, const char *label);
 static bool	error_cb(pdfio_file_t *pdf, const char *message, bool *error);
@@ -484,6 +485,96 @@ do_lzw_tests(void)
   }
 
   _pdfioLZWDelete(lzw);
+
+  return (status);
+}
+
+
+//
+// 'do_unicode_tests()' - Test UTF-8 to UTF-16 conversion for Unicode strings.
+//
+
+static int				// O - Exit status
+do_unicode_tests(void)
+{
+  int		status = 0;		// Exit status
+  char		filename[1024];		// Temporary PDF filename
+  pdfio_file_t	*pdf;			// PDF file
+  pdfio_dict_t	*dict;			// Page dictionary
+  pdfio_obj_t	*page;			// Page object
+  pdfio_stream_t *st;			// Content stream
+  char		buffer[1024];		// Content stream buffer
+  ssize_t	bytes;			// Bytes read
+  // "A" (U+0041), e-acute (U+00E9, 2-byte), Euro sign (U+20AC, 3-byte), and
+  // grinning face (U+1F600, 4-byte, supplementary plane).
+  static const char text[] = "A\xC3\xA9\xE2\x82\xAC\xF0\x9F\x98\x80";
+  static const char expected[] = "<004100E920ACD83DDE00>";
+
+
+  // Write a page that shows the string with a Unicode font...
+  testBegin("pdfioFileCreateTemporary(Unicode)");
+  if ((pdf = pdfioFileCreateTemporary(filename, sizeof(filename), /*version*/"2.0", /*media_box*/NULL, /*crop_box*/NULL, /*error_cb*/NULL, /*error_data*/NULL)) != NULL)
+  {
+    testEnd(true);
+  }
+  else
+  {
+    testEnd(false);
+    return (1);
+  }
+
+  dict = pdfioDictCreate(pdf);
+  pdfioPageDictAddFont(dict, "F1", pdfioFileCreateFontObjFromBase(pdf, "Helvetica"));
+
+  testBegin("pdfioContentTextShow(Unicode supplementary plane)");
+  if ((st = pdfioFileCreatePage(pdf, dict)) != NULL && pdfioContentTextBegin(st) && pdfioContentSetTextFont(st, "F1", 12.0) && pdfioContentTextMoveTo(st, 72.0, 720.0) && pdfioContentTextShow(st, /*unicode*/true, text) && pdfioContentTextEnd(st))
+  {
+    pdfioStreamClose(st);
+    pdfioFileClose(pdf);
+    testEnd(true);
+  }
+  else
+  {
+    testEnd(false);
+    return (1);
+  }
+
+  // Read the page content back and confirm the UTF-16 encoding...
+  testBegin("UTF-16 surrogate pair encoding");
+  if ((pdf = pdfioFileOpen(filename, /*password_cb*/NULL, /*password_data*/NULL, /*error_cb*/NULL, /*error_data*/NULL)) == NULL)
+  {
+    testEndMessage(false, "unable to reopen file");
+    return (1);
+  }
+
+  page = pdfioFileGetPage(pdf, 0);
+  dict = pdfioObjGetDict(page);
+
+  if ((st = pdfioObjOpenStream(pdfioDictGetObj(dict, "Contents"), /*decode*/true)) == NULL)
+  {
+    testEndMessage(false, "unable to open content stream");
+    pdfioFileClose(pdf);
+    return (1);
+  }
+
+  bytes = pdfioStreamRead(st, buffer, sizeof(buffer) - 1);
+  pdfioStreamClose(st);
+
+  if (bytes < 0)
+    bytes = 0;
+  buffer[bytes] = '\0';
+
+  if (strstr(buffer, expected))
+  {
+    testEnd(true);
+  }
+  else
+  {
+    testEndMessage(false, "expected \"%s\" in content stream", expected);
+    status = 1;
+  }
+
+  pdfioFileClose(pdf);
 
   return (status);
 }
@@ -1281,6 +1372,10 @@ do_unit_tests(void)
 
   // Do LZW tests...
   if (do_lzw_tests())
+    return (1);
+
+  // Do Unicode encoding tests...
+  if (do_unicode_tests())
     return (1);
 
   // Create a new PDF file...


### PR DESCRIPTION
`write_string()` mis-encodes any character at U+10000 or above when drawing text with `unicode=true`. Two bugs in the same branch: the threshold that picks a surrogate pair is `0x100000` instead of `0x10000`, so supplementary plane characters take the single-code-unit branch and print as a raw 5-hex-digit value (U+1F600 becomes `1F600`); and the surrogate formula never subtracts the `0x10000` bias, so even a character that reached the pair branch got the wrong high surrogate (`D87D` rather than `D83D`). Both produce malformed UTF-16 in the content stream for emoji, CJK extension blocks, and other non-BMP text.

The fix corrects the threshold and subtracts the bias before splitting into surrogates. BMP characters are unchanged.

Added a unit test in `do_unicode_tests()`: it writes `A`, U+00E9, U+20AC, and U+1F600 with `unicode=true`, reads the content stream back, and checks for `<004100E920ACD83DDE00>`.
